### PR TITLE
Filter by HTTP method

### DIFF
--- a/.circleci/.coveralls.yml
+++ b/.circleci/.coveralls.yml
@@ -1,3 +1,3 @@
 # php-coveralls
-coverage_clover: reports/clover.xml
-json_path: reports/coveralls.json
+coverage_clover: coverage/clover.xml
+json_path: coverage/coveralls.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /composer.lock
 
 # PHPUnit
-/reports
+/coverage
 
 # Misc
 .DS_Store

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -14,7 +14,7 @@
             <directory suffix=".php">src</directory>
         </include>
         <report>
-            <clover outputFile="reports/clover.xml"/>
+            <clover outputFile="coverage/clover.xml"/>
         </report>
     </coverage>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
             <directory suffix=".php">src</directory>
         </include>
         <report>
-            <html outputDirectory="reports"/>
+            <html outputDirectory="coverage"/>
         </report>
     </coverage>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,4 +13,11 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <RiskyTruthyFalsyComparison>
+            <errorLevel type="suppress">
+                <file name="src/Matcher/RegexMatcher.php" />
+            </errorLevel>
+        </RiskyTruthyFalsyComparison>
+    </issueHandlers>
 </psalm>

--- a/src/Matcher/RegexMatcher.php
+++ b/src/Matcher/RegexMatcher.php
@@ -69,8 +69,8 @@ class RegexMatcher implements MatcherInterface
      * 
      * @psalm-return non-empty-string
      * 
-     * @param string $method HTTP verb
-     * @return string        Compiled regex
+     * @param non-empty-string $method HTTP verb
+     * @return string                  Compiled regex
      */
     private function getRegex(string $method): string
     {
@@ -86,8 +86,8 @@ class RegexMatcher implements MatcherInterface
      * 
      * @psalm-return non-empty-string
      * 
-     * @param string $method HTTP verb
-     * @return string        Regular expression
+     * @param non-empty-string $method HTTP verb
+     * @return string                  Regular expression
      */
     private function compileRegex(string $method): string
     {

--- a/src/Matcher/RegexMatcher.php
+++ b/src/Matcher/RegexMatcher.php
@@ -21,8 +21,8 @@ class RegexMatcher implements MatcherInterface
 {
     private Collection $routes;
 
-    /** @psalm-var non-empty-string|null $compiled */
-    private ?string $compiled = null;
+    /** @var array<string, non-empty-string> $compiled */
+    private array $compiled = [];
 
     /**
      * Create a new matcher for dynamic routes
@@ -34,9 +34,9 @@ class RegexMatcher implements MatcherInterface
         $this->routes = $routes;
     }
 
-    public function match(string $url): ?MatchedRoute
+    public function match(string $url, string $method = 'GET'): ?MatchedRoute
     {
-        $regex = $this->getRegex();
+        $regex = $this->getRegex($method);
             
         if (!preg_match($regex, $url, $matches) || empty($matches["MARK"])) {
             return null;
@@ -69,15 +69,16 @@ class RegexMatcher implements MatcherInterface
      * 
      * @psalm-return non-empty-string
      * 
-     * @param string Regular expression
+     * @param string $method HTTP verb
+     * @return string        Compiled regex
      */
-    private function getRegex(): string
+    private function getRegex(string $method): string
     {
-        if ($this->compiled === null) {
-            $this->compiled = $this->compileRegex();
+        if (!isset($this->compiled[$method])) {
+            $this->compiled[$method] = $this->compileRegex($method);
         }
 
-        return $this->compiled;
+        return $this->compiled[$method];
     }
 
     /**
@@ -85,14 +86,17 @@ class RegexMatcher implements MatcherInterface
      * 
      * @psalm-return non-empty-string
      * 
-     * @return string Regular expression
+     * @param string $method HTTP verb
+     * @return string        Regular expression
      */
-    private function compileRegex(): string
+    private function compileRegex(string $method): string
     {
         $regexes = [];
 
         foreach ($this->routes->dynamic() as $name => $route) {
-            $regexes[] = "(?>{$this->compileRoute($route)}(*:{$name}))";
+            if ($route->supports($method)) {
+                $regexes[] = "(?>{$this->compileRoute($route)}(*:{$name}))";
+            }
         }
 
         return '~^(?|' . implode('|', $regexes) . ')$~ixX';

--- a/src/Matcher/SeriesMatcher.php
+++ b/src/Matcher/SeriesMatcher.php
@@ -23,10 +23,12 @@ class SeriesMatcher implements MatcherInterface
         $this->matchers = $matchers;
     }
 
-    public function match(string $url): ?MatchedRoute
+    public function match(string $url, string $method = 'GET'): ?MatchedRoute
     {
         foreach ($this->matchers as $matcher) {
-            if (($match = $matcher->match($url)) !== null) return $match;
+            if (null !== ($match = $matcher->match($url, $method))) {
+                return $match;
+            }
         }
 
         return null;

--- a/src/Matcher/StaticMatcher.php
+++ b/src/Matcher/StaticMatcher.php
@@ -25,12 +25,12 @@ class StaticMatcher implements MatcherInterface
         $this->routes = $routes;
     }
 
-    public function match(string $url): ?MatchedRoute
+    public function match(string $url, string $method = 'GET'): ?MatchedRoute
     {
         $matched = null;
 
         foreach ($this->routes->static() as $name => $route) {
-            if ($route->getComponent(0) === $url) {
+            if ($route->supports($method) && $route->getComponent(0) === $url) {
                 $matched = new MatchedRoute($name, $route);
                 break;
             }

--- a/src/MatcherInterface.php
+++ b/src/MatcherInterface.php
@@ -10,10 +10,14 @@ use Swiftly\Routing\MatchedRoute;
 interface MatcherInterface
 {
     /**
-     * Attempt to find a route that matches the given URL path
-     * 
+     * Attempt to find a route that matches the given URL path.
+     *
+     * Can provide a `$method` to filter by routes that support a given HTTP
+     * verb.
+     *
      * @param string $url        URL path
+     * @param string $method     Request method
      * @return MatchedRoute|null Matched route
      */
-    public function match(string $url): ?MatchedRoute;
+    public function match(string $url, string $method = 'GET'): ?MatchedRoute;
 }

--- a/src/MatcherInterface.php
+++ b/src/MatcherInterface.php
@@ -15,9 +15,9 @@ interface MatcherInterface
      * Can provide a `$method` to filter by routes that support a given HTTP
      * verb.
      *
-     * @param string $url        URL path
-     * @param string $method     Request method
-     * @return MatchedRoute|null Matched route
+     * @param string $url              URL path
+     * @param non-empty-string $method Request method
+     * @return MatchedRoute|null       Matched route
      */
     public function match(string $url, string $method = 'GET'): ?MatchedRoute;
 }

--- a/src/Parser/DefaultParser.php
+++ b/src/Parser/DefaultParser.php
@@ -88,7 +88,7 @@ class DefaultParser implements ParserInterface
      */
     private function split(string $path): ?array
     {
-        if (!preg_match_all(self::SPLIT_REGEX, $path, $matches, PREG_SET_ORDER)) {
+        if (false === preg_match_all(self::SPLIT_REGEX, $path, $matches, PREG_SET_ORDER)) {
             return null;
         }
         

--- a/tests/Matcher/RegexMatcherTest.php
+++ b/tests/Matcher/RegexMatcherTest.php
@@ -28,6 +28,9 @@ Class RegexMatcherTest Extends TestCase
         $this->matcher = new RegexMatcher($this->collection);
     }
 
+    /**
+     * @return MockObject&Route
+     */
     private function createMockRoute(): Route
     {
         $component = $this->createMock(ComponentInterface::class);
@@ -46,6 +49,10 @@ Class RegexMatcherTest Extends TestCase
     public function testCanMatchDynamicRoute(): void
     {
         $route = self::createMockRoute();
+        $route->expects(self::once())
+            ->method('supports')
+            ->with('GET')
+            ->willReturn(true);
 
         $this->collection->method('dynamic')
             ->willReturn(['view' => $route]);

--- a/tests/Matcher/StaticMatcherTest.php
+++ b/tests/Matcher/StaticMatcherTest.php
@@ -27,6 +27,9 @@ Class StaticMatcherTest Extends TestCase
         $this->matcher = new StaticMatcher($this->collection);
     }
 
+    /**
+     * @return MockObject&Route
+     */
     public function createMockRoute(): Route
     {
         $route = $this->createMock(Route::class);
@@ -41,15 +44,16 @@ Class StaticMatcherTest Extends TestCase
     public function testCanMatchStaticRoute(): void
     {
         $route = $this->createMockRoute();
+        $route->expects(self::exactly(2))
+            ->method('supports')
+            ->with('GET')
+            ->willReturn(true);
 
         $this->collection->method('static')
             ->willReturn(['view' => $route]);
 
         $match = $this->matcher->match('/admin');
 
-        /**
-         * Matchers now return a dedicated @see {MatchedRoute} P.O.D
-         */
         self::assertInstanceOf(MatchedRoute::class, $match);
         self::assertSame('view', $match->name);
         self::assertSame($route, $match->route);


### PR DESCRIPTION
Allow passing a HTTP verb (`GET`, `POST`,`PUT` etc) with which to filter the matched route.